### PR TITLE
adding "shimmed" state to compatibility tracking

### DIFF
--- a/js/addons.js
+++ b/js/addons.js
@@ -14,6 +14,8 @@
                 var name = row.title;
                 var notes = row["notes"];
                 var users = row["users"];
+                var shimmed = row["shimmed"];
+                var cpow = row["cpow"];
 
                 bugURL = null;
                 compatible = null;
@@ -39,7 +41,7 @@
                     URL = "https://www.google.com/search?btnI=1&q=site%3Aaddons.mozilla.org+" + name;
                 }
 
-                var addon = {name:name, URL:URL, date:date, compatible:compatible, bug:bug, bugURL:bugURL, notes:notes, users:users};
+                var addon = {name:name, URL:URL, date:date, compatible:compatible, bug:bug, bugURL:bugURL, notes:notes, users:users, shimmed:shimmed, cpow:cpow};
                 if (bug) {
                     bugToAddonMap[bug] = addon;
                 }

--- a/js/index.js
+++ b/js/index.js
@@ -75,13 +75,13 @@
                             shimmedCount++;
                         }
                     } else if (addon.compatible === null) {
-                            compatible = "not tested";
-                            style = "info"; // blue
-                            untestedCount++;
+                        compatible = "not tested";
+                        style = "info"; // blue
+                        untestedCount++;
                     } else {
-                            compatible = "bug reported";
-                            style = "danger"; // red
-                            brokenCount++;
+                        compatible = "bug reported";
+                        style = "danger"; // red
+                        brokenCount++;
                     }
                     
                     var tr = document.createElement("tr");

--- a/js/index.js
+++ b/js/index.js
@@ -50,7 +50,7 @@
                 var bugzillaURL = 'https://bugzilla.mozilla.org/enter_bug.cgi?format=__default__&product=Firefox&component=Extension%20Compatibility&blocked=905436&keywords=addon-compat&short_desc="' + addon.name + '"%20add-on%20does%20not%20work%20with%20e10s&cc=cpeterson@mozilla.com,jmathies@mozilla.com,lshapiro@mozilla.com&';
                 var reportBugLink = createLink(bugzillaURL, "Report bug");
 
-                var mailtoURL = 'mailto:cpeterson@mozilla.com?cc=jmathies@mozilla.com,lshapiro@mozilla.com&subject="' + addon.name + '" add-on works with e10s!&body=Add-on:%0A' + addon.name + '%0A%0AUser-Agent:%0A' + encodeURIComponent(navigator.userAgent);
+                var mailtoURL = 'mailto:cpeterson@mozilla.com?cc=jmathies@mozilla.com,lshapiro@mozilla.com,twalker@mozilla.com&subject="' + addon.name + '" add-on works with e10s!&body=Add-on:%0A' + addon.name + '%0A%0AUser-Agent:%0A' + encodeURIComponent(navigator.userAgent);
                 var itWorksLink = createLink(mailtoURL, 'it works');
 
                 var td = createElement("td");
@@ -65,19 +65,25 @@
                 _.forEach(addons, function(addon) {
                     var compatible, style;
                     if (addon.compatible) {
-                        compatible = "compatible";
-                        style = "success"; // green
-                        compatCount++;
+                        if (addon.shimmed !== "TRUE") {
+                            compatible = "compatible";
+                            style = "success"; // green
+                            compatCount++;
+                        } else {
+                            compatible = "shimmed"
+                            style = "warning"; // yellow
+                            shimmedCount++;
+                        }
                     } else if (addon.compatible === null) {
-                        compatible = "not tested";
-                        style = "warning"; // yellow
-                        untestedCount++;
+                            compatible = "not tested";
+                            style = "info"; // blue
+                            untestedCount++;
                     } else {
-                        compatible = "bug reported";
-                        style = "danger"; // red
-                        brokenCount++;
+                            compatible = "bug reported";
+                            style = "danger"; // red
+                            brokenCount++;
                     }
-
+                    
                     var tr = document.createElement("tr");
                     tr.setAttribute("class", style);
                     tr.appendChild(createElement("td", createLink(addon.URL, decodeURIComponent(addon.name))));
@@ -92,7 +98,7 @@
             var compatCount = 0;
             var untestedCount = 0;
             var brokenCount = 0;
-            // var slowCount = 0;
+            var shimmedCount = 0;
                       
               
             $addons.parseSpreadsheet(json, function(error, addons) {
@@ -100,6 +106,7 @@
                 var untestedAddons = [];
                 var badAddons = [];
                 var popularAddons = [];
+                var shimmedAddons = [];
 
                 _.forEach(addons, function(addon) {
                     var array;
@@ -108,7 +115,11 @@
                     }
                     else
                         if (addon.compatible) {
-                            array = goodAddons;
+                            if (addons.shimmed == "FALSE") {
+                                array = goodAddons;
+                            } else {
+                                array = shimmedAddons;
+                            }  
                         } else if (addon.compatible === null) {
                             array = untestedAddons;
                         } else {
@@ -119,6 +130,7 @@
                 
                 sortByUsers(popularAddons);
                 shuffleArray(untestedAddons);
+                sortByUsers(shimmedAddons);
                 sortByUsers(goodAddons);
                 sortByUsers(badAddons);
 
@@ -141,16 +153,15 @@
             fragment.appendChild(tr);
             tbl.appendChild(fragment);
             
-            // place holder for fourth state
-            // var count = slow.toString();
-            // var fragment = document.createDocumentFragment();
-            // var tr = document.createElement("tr");
-            // tbl.appendChild(fragment);
-            // tr.style.backgroundColor = "#E5E4E2"; // grey
-            // tr.appendChild(createElement("td", "Slow"));
-            // tr.appendChild(createElement("td", "???"));
-            // fragment.appendChild(tr);
-            // tbl.appendChild(fragment);
+            var count = shimmedCount.toString();
+            var fragment = document.createDocumentFragment();
+            var tr = document.createElement("tr");
+            tbl.appendChild(fragment);
+            tr.setAttribute("class", "warning"); // yellow
+            tr.appendChild(createElement("td", "Shimmed"));
+            tr.appendChild(createElement("td", count));
+            fragment.appendChild(tr);
+            tbl.appendChild(fragment);
               
             var count = brokenCount.toString();
             var fragment = document.createDocumentFragment();
@@ -164,7 +175,7 @@
             var count = untestedCount.toString();
             var fragment = document.createDocumentFragment();
             var tr = document.createElement("tr");
-            tr.setAttribute("class", "warning"); // yellow
+            tr.setAttribute("class", "info"); // blue
             tr.appendChild(createElement("td", "Untested"));
             tr.appendChild(createElement("td", count));
             fragment.appendChild(tr);


### PR DESCRIPTION
added rows in the spreadsheet from telemetry data showing time in CPOW and if add-on is known to be shimmed.  Used that information to display if addon is compatible but shimmed.